### PR TITLE
allow custom path to electron as optional first parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,17 @@ electronVersion(function (err, v) {
 })
 ```
 
+You can optionally specify a custom path to the `electron` binary.
+
+```js
+const path = require('path')
+const electronVersion = require('electron-version')
+const electronPath = path.join(__dirname, 'node_modules/.bin/electron')
+
+electronVersion(electronPath, function (err, v) {
+  console.log(err, v) // null 'v1.6.3'
+})
+```
+
 ## License
 All code, unless stated otherwise, is licensed under the [`WTFPL`](http://www.wtfpl.net/txt/copying/) license.

--- a/index.js
+++ b/index.js
@@ -3,9 +3,14 @@ const once = require('once')
 const bl = require('bl')
 const semver = require('semver')
 
-function electronVersion (cb) {
+function electronVersion (electronPath, cb) {
+  if (!cb) {
+    cb = electronPath
+    electronPath = 'electron'
+  }
+
   cb = once(cb)
-  var c = cp.spawn('electron', [ '--version' ])
+  var c = cp.spawn(electronPath, [ '--version' ])
   c.on('error', cb)
   c.on('exit', function (code) {
     if (code !== 0) return cb(new Error('no electron installed'))

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 const test = require('tape')
+const path = require('path')
 const electronVersion = require('../')
 const cp = require('child_process')
 const EE = require('events').EventEmitter
@@ -36,6 +37,17 @@ test('returns version if correct semver', function (t) {
   electronVersion(function (err, v) {
     t.error(err)
     t.equal(v, 'v0.33.1', 'correct version')
+    t.end()
+  })
+})
+
+test('accepts a custom electron path', function (t) {
+  mockSpawn(function (s) {
+    process.nextTick(s.end.bind(s, 'v1.6.3'))
+  })
+  electronVersion(path.join(__dirname, 'node_modules/.bin/electron'), function (err, v) {
+    t.error(err)
+    t.equal(v, 'v1.6.3', 'correct version')
     t.end()
   })
 })


### PR DESCRIPTION
This PR allows a custom path to the electron binary to be passed as the first argument. This should probably just be a minor version bump as the existing functionality remains unchanged.

This is a way to unblock https://github.com/electron/spectron/pull/166

How does this look, @ralphtheninja?